### PR TITLE
Added documentation on rom tools compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ spasm -E -A skin.asm TIBoySkn.8xv
 ```
 To build the rom generation tool, use the provided Visual Studio solution in the [tiboyce-romgen](tiboyce-romgen) directory, or you can build the source for any platform with your C compiler of choice.
 
+Example(GCC):
+```
+cd <romgen dir>
+gcc romgen.c zip.c -o romgen
+```
+```
+cd <convertsav dir>
+gcc convertsav.c lzf_c.c lzf_d.c -o convertsav
+```
+
+
 The same applies to the save converter in the [tiboyce-convertsav](tiboyce-convertsav) directory.
 
 ## Issues / Bugs

--- a/README.md
+++ b/README.md
@@ -137,13 +137,11 @@ Example(GCC):
 cd <romgen dir>
 gcc romgen.c zip.c -o romgen
 ```
+The same applies to the save converter in the [tiboyce-convertsav](tiboyce-convertsav) directory.
 ```
 cd <convertsav dir>
 gcc convertsav.c lzf_c.c lzf_d.c -o convertsav
 ```
-
-
-The same applies to the save converter in the [tiboyce-convertsav](tiboyce-convertsav) directory.
 
 ## Issues / Bugs
 


### PR DESCRIPTION
Added in an example showing how to compile `romgen` and `convertsav` using a gcc compiler. I figure `gcc` was the most commonly used and is supported on a very wide variety of devices.