### PR TITLE
romgen: don't add leading zeros to the checksum in bundles.

### DIFF
--- a/tiboyce-romgen/romgen.c
+++ b/tiboyce-romgen/romgen.c
@@ -739,8 +739,8 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 		char checksum_str[11];
-		sprintf(checksum_str, "%08x\r\n", checksum);
-		if (zip_entry_write(zip, checksum_str, 10) < 0)
+		int checksum_str_len = sprintf(checksum_str, "%x\r\n", checksum);
+		if (zip_entry_write(zip, checksum_str, checksum_str_len) < 0)
 		{
 			zip_entry_close(zip);
 			write_error("_CHECKSUM", zip);


### PR DESCRIPTION
TI-Connect CE doesn't like them, and throws an error when the
user tries to transfer such a bundle to a calculator.

How odd nobody encountered that...