### PR TITLE
Create windows and unix build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ script:
   - make NO_APPSIGN=1 -j2
   - cp ./spasm ../spasm
   - cd ..
-  - ./spasm -E -A launcher.asm TIBOYCE.8xp
-  - ./spasm -E -A tiboyce.asm TIBoyDat.8xv
-  - ./spasm -E -A skin.asm TIBoySkn.8xv
+  - ./build.sh
   - cd tiboyce-romgen
   - gcc -std=c99 -O2 -W -Wall -Wextra -Wno-pointer-sign -Wno-unused-parameter -o romgen romgen.c zip.c
   - cd ../tiboyce-convertsav

--- a/README.md
+++ b/README.md
@@ -182,18 +182,11 @@ If you get a missing DLL error when running the command-line utility, you may ne
 
 ## Build Instructions
 
-To build the emulator from source, first grab the latest release of [SPASM-ng](https://github.com/alberthdev/spasm-ng/releases).
+To build the emulator:
+1.  Obtain [SPASM-ng](https://github.com/alberthdev/spasm-ng). Commit [5f0786d](https://github.com/alberthdev/spasm-ng/commit/5f0786d38f064835be674d4b7df42969967bb73c) is required to build TI-Boy CE successfully. As of July 22 2024, there is no official release containing this commit; see https://github.com/alberthdev/spasm-ng/issues/88.
+2.  Name the SPASM-ng executable "spasm" and place it in the repo root directory or somewhere in the executable search path.
+3.  From the repo root directory, run `build.bat` if on Windows or `build.sh` if on some other OS.
 
-A build newer than SPASM-ng v0.5-beta.3 is required to build TI-Boy CE properly; currently, there is not a release corresponding to that so you must build it yourself.
-
-For simplicity's sake, I'll call the name of the executable `spasm` below. Run the following to produce the emulator files:
-```
-spasm -E -A launcher.asm TIBOYCE.8xp
-
-spasm -E -A tiboyce.asm TIBoyDat.8xv
-
-spasm -E -A skin.asm TIBoySkn.8xv
-```
 To build the rom generation tool, use the provided Visual Studio solution in the [tiboyce-romgen](tiboyce-romgen) directory, or use the Makefile to build with GCC or your C compiler of choice.
 
 The same applies to the save converter in the [tiboyce-convertsav](tiboyce-convertsav) directory.

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,8 @@
 @echo off
+set exit_timeout=-1
 
 for /f %%i in ('git describe --tags') do set "version=%%i" && goto version_ok
-exit /b
+goto exit
 :version_ok
 
 set "as=spasm -E -T -L -A"
@@ -10,7 +11,18 @@ set "build=build"
 if not exist %build% mkdir %build%
 
 @echo on
+%as% -DVERSION=\"%version%\" tiboyce.asm %build%/TIBoyDat.8xv || goto exit
+%as% launcher.asm %build%/TIBOYCE.8xp || goto exit
+%as% skin.asm %build%/TIBoySkn.8xv || goto exit
+@echo off
 
-%as% -DVERSION=\"%version%\" tiboyce.asm %build%/TIBoyDat.8xv || exit /b
-%as% launcher.asm %build%/TIBOYCE.8xp || exit /b
-%as% skin.asm %build%/TIBoySkn.8xv || exit /b
+echo.
+echo Success!
+set exit_timeout=5
+
+:exit
+@echo off
+@REM Pause if not run from cmd so the window persists and the user can see the output.
+@REM https://superuser.com/a/1688485
+if /i not "%CMDCMDLINE:"=%" == "%COMSPEC%" timeout /t %exit_timeout%
+exit /b

--- a/build.bat
+++ b/build.bat
@@ -8,12 +8,12 @@ goto exit
 set "as=spasm -E -T -L -A"
 set "build=build"
 
-if not exist %build% mkdir %build%
+if not exist "%build%" mkdir "%build%"
 
 @echo on
-%as% -DVERSION="\"%version%\"" tiboyce.asm %build%/TIBoyDat.8xv || goto exit
-%as% launcher.asm %build%/TIBOYCE.8xp || goto exit
-%as% skin.asm %build%/TIBoySkn.8xv || goto exit
+%as% -DVERSION="\"%version%\"" tiboyce.asm "%build%/TIBoyDat.8xv" || goto exit
+%as% launcher.asm "%build%/TIBOYCE.8xp" || goto exit
+%as% skin.asm "%build%/TIBoySkn.8xv" || goto exit
 @echo off
 
 echo.

--- a/build.bat
+++ b/build.bat
@@ -3,7 +3,7 @@ set exit_timeout=-1
 @echo on
 
 set version_arg=
-for /f %%i in ('git describe --tags "--dirty=*"') do set "version_arg="-DVERSION=\"%%i\"""
+for /f %%i in ('git describe --tags "--dirty=*" "--abbrev=7"') do set "version_arg="-DVERSION=\"%%i\"""
 set "as=spasm -E -T -L -A"
 set "build=build"
 

--- a/build.bat
+++ b/build.bat
@@ -11,7 +11,7 @@ set "build=build"
 if not exist %build% mkdir %build%
 
 @echo on
-%as% -DVERSION=\"%version%\" tiboyce.asm %build%/TIBoyDat.8xv || goto exit
+%as% -DVERSION="\"%version%\"" tiboyce.asm %build%/TIBoyDat.8xv || goto exit
 %as% launcher.asm %build%/TIBOYCE.8xp || goto exit
 %as% skin.asm %build%/TIBoySkn.8xv || goto exit
 @echo off

--- a/build.bat
+++ b/build.bat
@@ -1,12 +1,16 @@
 @echo off
 
-set as=spasm -E -T -L -A
-set build=build
+for /f %%i in ('git describe --tags') do set "version=%%i" && goto version_ok
+exit /b
+:version_ok
+
+set "as=spasm -E -T -L -A"
+set "build=build"
 
 if not exist %build% mkdir %build%
 
 @echo on
 
-%as% launcher.asm %build%/TIBOYCE.8xp
-%as% tiboyce.asm %build%/TIBoyDat.8xv
-%as% skin.asm %build%/TIBoySkn.8xv
+%as% -DVERSION=\"%version%\" tiboyce.asm %build%/TIBoyDat.8xv || exit /b
+%as% launcher.asm %build%/TIBOYCE.8xp || exit /b
+%as% skin.asm %build%/TIBoySkn.8xv || exit /b

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,12 @@
+@echo off
+
+set as=spasm -E -T -L -A
+set build=build
+
+if not exist %build% mkdir %build%
+
+@echo on
+
+%as% launcher.asm %build%/TIBOYCE.8xp
+%as% tiboyce.asm %build%/TIBoyDat.8xv
+%as% skin.asm %build%/TIBoySkn.8xv

--- a/build.bat
+++ b/build.bat
@@ -6,7 +6,7 @@ for /f %%i in ('git describe --tags "--dirty=*"') do set "version=%%i" && goto v
 goto exit
 :version_ok
 
-set "as=spasm -E -T -L -A"
+set "as=spasm -E -T -L -A %*"
 set "build=build"
 
 if not exist "%build%" mkdir "%build%"

--- a/build.bat
+++ b/build.bat
@@ -4,14 +4,14 @@ set exit_timeout=-1
 
 set version_arg=
 for /f %%i in ('git describe --tags "--dirty=*"') do set "version_arg="-DVERSION=\"%%i\"""
-set "as=spasm -E -T -L -A %*"
+set "as=spasm -E -T -L -A"
 set "build=build"
 
 if not exist "%build%" mkdir "%build%"
 
-%as% %version_arg% tiboyce.asm "%build%/TIBoyDat.8xv" || goto exit
-%as% launcher.asm "%build%/TIBOYCE.8xp" || goto exit
-%as% skin.asm "%build%/TIBoySkn.8xv" || goto exit
+%as% %version_arg% %* tiboyce.asm "%build%/TIBoyDat.8xv" || goto exit
+%as% %* launcher.asm "%build%/TIBOYCE.8xp" || goto exit
+%as% %* skin.asm "%build%/TIBoySkn.8xv" || goto exit
 
 @echo off
 echo.

--- a/build.bat
+++ b/build.bat
@@ -1,5 +1,6 @@
 @echo off
 set exit_timeout=-1
+@echo on
 
 for /f %%i in ('git describe --tags "--dirty=*"') do set "version=%%i" && goto version_ok
 goto exit
@@ -10,12 +11,11 @@ set "build=build"
 
 if not exist "%build%" mkdir "%build%"
 
-@echo on
 %as% -DVERSION="\"%version%\"" tiboyce.asm "%build%/TIBoyDat.8xv" || goto exit
 %as% launcher.asm "%build%/TIBOYCE.8xp" || goto exit
 %as% skin.asm "%build%/TIBoySkn.8xv" || goto exit
-@echo off
 
+@echo off
 echo.
 echo Success!
 set exit_timeout=5

--- a/build.bat
+++ b/build.bat
@@ -2,16 +2,14 @@
 set exit_timeout=-1
 @echo on
 
-for /f %%i in ('git describe --tags "--dirty=*"') do set "version=%%i" && goto version_ok
-goto exit
-:version_ok
-
+set version_arg=
+for /f %%i in ('git describe --tags "--dirty=*"') do set "version_arg="-DVERSION=\"%%i\"""
 set "as=spasm -E -T -L -A %*"
 set "build=build"
 
 if not exist "%build%" mkdir "%build%"
 
-%as% -DVERSION="\"%version%\"" tiboyce.asm "%build%/TIBoyDat.8xv" || goto exit
+%as% %version_arg% tiboyce.asm "%build%/TIBoyDat.8xv" || goto exit
 %as% launcher.asm "%build%/TIBOYCE.8xp" || goto exit
 %as% skin.asm "%build%/TIBoySkn.8xv" || goto exit
 

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,7 @@
 @echo off
 set exit_timeout=-1
 
-for /f %%i in ('git describe --tags') do set "version=%%i" && goto version_ok
+for /f %%i in ('git describe --tags "--dirty=*"') do set "version=%%i" && goto version_ok
 goto exit
 :version_ok
 

--- a/build.sh
+++ b/build.sh
@@ -5,9 +5,8 @@ version=$(git describe --tags --dirty=*)
 as="spasm -E -T -L -A"
 build="build"
 
-mkdir -p $build
+mkdir -p "$build"
 
-set -x
-$as -DVERSION="\"$version\"" tiboyce.asm $build/TIBoyDat.8xv
-$as launcher.asm $build/TIBOYCE.8xp
-$as skin.asm $build/TIBoySkn.8xv
+$as -DVERSION="\"$version\"" tiboyce.asm "$build/TIBoyDat.8xv"
+$as launcher.asm "$build/TIBOYCE.8xp"
+$as skin.asm "$build/TIBoySkn.8xv"

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,6 @@ build="build"
 mkdir -p $build
 
 set -x
-
 $as -DVERSION=\"$version\" tiboyce.asm $build/TIBoyDat.8xv
 $as launcher.asm $build/TIBOYCE.8xp
 $as skin.asm $build/TIBoySkn.8xv

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,6 @@ build="build"
 mkdir -p $build
 
 set -x
-$as -DVERSION=\"$version\" tiboyce.asm $build/TIBoyDat.8xv
+$as -DVERSION="\"$version\"" tiboyce.asm $build/TIBoyDat.8xv
 $as launcher.asm $build/TIBOYCE.8xp
 $as skin.asm $build/TIBoySkn.8xv

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-version_arg="-DVERSION=\"$(git describe --tags --dirty=*)\"" || unset version_arg
+version_arg="-DVERSION=\"$(git describe --tags --dirty=* --abbrev=7)\"" || unset version_arg
 set -e
 as="spasm -E -T -L -A"
 build="build"

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,6 @@ build="build"
 
 mkdir -p "$build"
 
-$as -DVERSION="\"$version\"" tiboyce.asm "$build/TIBoyDat.8xv"
-$as launcher.asm "$build/TIBOYCE.8xp"
-$as skin.asm "$build/TIBoySkn.8xv"
+$as "$@" -DVERSION="\"$version\"" tiboyce.asm "$build/TIBoyDat.8xv"
+$as "$@" launcher.asm "$build/TIBOYCE.8xp"
+$as "$@" skin.asm "$build/TIBoySkn.8xv"

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -ex
 
 version=$(git describe --tags --dirty=*)
 as="spasm -E -T -L -A"

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-version=$(git describe --tags)
+version=$(git describe --tags --dirty=*)
 as="spasm -E -T -L -A"
 build="build"
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+as="spasm -E -T -L -A"
+build="build"
+
+mkdir -p $build
+
+set -x
+
+$as launcher.asm $build/TIBOYCE.8xp
+$as tiboyce.asm $build/TIBoyDat.8xv
+$as skin.asm $build/TIBoySkn.8xv

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
+set -e
 
+version=$(git describe --tags)
 as="spasm -E -T -L -A"
 build="build"
 
@@ -7,6 +9,6 @@ mkdir -p $build
 
 set -x
 
+$as -DVERSION=\"$version\" tiboyce.asm $build/TIBoyDat.8xv
 $as launcher.asm $build/TIBOYCE.8xp
-$as tiboyce.asm $build/TIBoyDat.8xv
 $as skin.asm $build/TIBoySkn.8xv

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,13 @@
-#!/bin/sh
-set -ex
+#!/bin/bash
+set -x
 
-version=$(git describe --tags --dirty=*)
+version_arg="-DVERSION=\"$(git describe --tags --dirty=*)\"" || unset version_arg
+set -e
 as="spasm -E -T -L -A"
 build="build"
 
 mkdir -p "$build"
 
-$as "$@" -DVERSION="\"$version\"" tiboyce.asm "$build/TIBoyDat.8xv"
+$as "$@" ${version_arg+"$version_arg"} tiboyce.asm "$build/TIBoyDat.8xv"
 $as "$@" launcher.asm "$build/TIBOYCE.8xp"
 $as "$@" skin.asm "$build/TIBoySkn.8xv"

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,6 @@ build="build"
 
 mkdir -p "$build"
 
-$as "$@" ${version_arg+"$version_arg"} tiboyce.asm "$build/TIBoyDat.8xv"
+$as ${version_arg+"$version_arg"} "$@" tiboyce.asm "$build/TIBoyDat.8xv"
 $as "$@" launcher.asm "$build/TIBOYCE.8xp"
 $as "$@" skin.asm "$build/TIBoySkn.8xv"

--- a/menu.asm
+++ b/menu.asm
@@ -1395,8 +1395,13 @@ MenuTemplate:
 MainMenu:
 	.db 10
 
-	.db 5,8
-	.db "TI-Boy CE Alpha v0.3.0\nhttps://calc84maniac.github.io/tiboyce",0
+VersionLengthBegin:
+	.db VERSION
+VersionLength = $ - VersionLengthBegin
+	.seek VersionLengthBegin
+	.org VersionLengthBegin
+	.db 5, 11 - (VersionLength / 2)
+	.db "TI-Boy CE Alpha ",VERSION,"\nhttps://calc84maniac.github.io/tiboyce",0
 
 	.db "Select to load the game state from the\ncurrent slot for this game.\nPress left/right to change the slot.",0
 	.db ITEM_DIGIT | ITEM_ROMONLY

--- a/tiboyce.asm
+++ b/tiboyce.asm
@@ -1,3 +1,8 @@
+#ifndef VERSION
+; "*" indicates a potentially modified, or "dirty" in Git terminology, version.
+#define VERSION "v0.3.0*"
+#endif
+
 #ifdef FASTLOG
 #define FASTLOG_EVENT_RUNTIME_ERROR $DE
 #define FASTLOG_EVENT_INVALID_OPCODE $AD


### PR DESCRIPTION
Output of `build.bat` at daf0ec6ce49ead5057ad895b016eef46527f7e43:

```
C:\Users\zwass\OneDrive\Documents\TI\_84+CE\tiboyce>set version_arg= 

C:\Users\zwass\OneDrive\Documents\TI\_84+CE\tiboyce>for /F %i in ('git describe --tags "--dirty=*" "--abbrev=7"') do set "version_arg="-DVERSION=\"%i\""" 

C:\Users\zwass\OneDrive\Documents\TI\_84+CE\tiboyce>set "version_arg="-DVERSION=\"v0.3.0-18-gb2e5aec\""" 

C:\Users\zwass\OneDrive\Documents\TI\_84+CE\tiboyce>set "as=spasm -E -T -L -A" 

C:\Users\zwass\OneDrive\Documents\TI\_84+CE\tiboyce>set "build=build"

C:\Users\zwass\OneDrive\Documents\TI\_84+CE\tiboyce>if not exist "build" mkdir "build"

C:\Users\zwass\OneDrive\Documents\TI\_84+CE\tiboyce>spasm -E -T -L -A "-DVERSION=\"v0.3.0-18-gb2e5aec\""  tiboyce.asm "build/TIBoyDat.8xv"   || goto exit        
Pass one...
Pass two... 
Opcycle routine size: 251
LZF compressor size: 320
LZF decompressor size: 95
User RAM code size: 14249
User RAM program size: 14297
SHA code size: 63
GBC SHA code size: 63
5 bytes remaining for port writes
Z80 mode code size: 10002
Opgen routine size: 256
Cursor memory code size: 1006
GBC cursor memory code size: 1022
Total size: 42478
Assembly time: 0.211 seconds

C:\Users\zwass\OneDrive\Documents\TI\_84+CE\tiboyce>spasm -E -T -L -A  launcher.asm "build/TIBOYCE.8xp"   || goto exit
Pass one... 
Pass two...
Loader size is 440 bytes
Assembly time: 0.002 seconds

C:\Users\zwass\OneDrive\Documents\TI\_84+CE\tiboyce>spasm -E -T -L -A  skin.asm "build/TIBoySkn.8xv"   || goto exit
Pass one...
Pass two... 
Assembly time: 0.003 seconds

Success!
```

Output of `build.sh` at b2e5aec14adaf36ca06e4202ccd877bdc62c1654:

```
++ git describe --tags '--dirty=*' --abbrev=7
+ version_arg='-DVERSION="v0.3.0-18-gb2e5aec"'
+ set -e
+ as='spasm -E -T -L -A'
+ build=build
+ mkdir -p build
+ spasm -E -T -L -A '-DVERSION="v0.3.0-18-gb2e5aec"' tiboyce.asm build/TIBoyDat.8xv
Pass one... 
Pass two... 
Opcycle routine size: 251
LZF compressor size: 320
LZF decompressor size: 95
User RAM code size: 14249
User RAM program size: 14297
SHA code size: 63
GBC SHA code size: 63
5 bytes remaining for port writes
Z80 mode code size: 10002
Opgen routine size: 256
Cursor memory code size: 1006
GBC cursor memory code size: 1022
Total size: 42478
Assembly time: 0.221 seconds
+ spasm -E -T -L -A launcher.asm build/TIBOYCE.8xp
Pass one... 
Pass two...
Loader size is 440 bytes
Assembly time: 0.001 seconds
+ spasm -E -T -L -A skin.asm build/TIBoySkn.8xv
Pass one... 
Pass two...
Assembly time: 0.004 seconds
```

Screenshot of the main TI-Boy CE settings page at daf0ec6ce49ead5057ad895b016eef46527f7e43:

![image](https://github.com/user-attachments/assets/2ee18539-2589-49fc-b815-1f077df4f8b7)

Screenshot of the main TI-Boy CE settings page at daf0ec6ce49ead5057ad895b016eef46527f7e43 with a dirty working tree:

![image](https://github.com/user-attachments/assets/76b18965-05b5-46a5-8e5a-89b2cee99fb2)

Screenshot of the main TI-Boy CE settings page at daf0ec6ce49ead5057ad895b016eef46527f7e43 tagged as "v0.3.1":

![image](https://github.com/user-attachments/assets/6abe942c-f82f-4b74-971f-930138e42803)

Screenshot of the main TI-Boy CE settings page at daf0ec6ce49ead5057ad895b016eef46527f7e43 tagged as "v0.3.1" with a dirty working tree:

![image](https://github.com/user-attachments/assets/f7f8c852-85f9-40ec-88dc-7fad89c63a9c)

Screenshot of the main TI-Boy CE settings page at daf0ec6ce49ead5057ad895b016eef46527f7e43 with `git describe` failure:

![image](https://github.com/user-attachments/assets/01f44f53-0809-4d07-8deb-d3609eeca9b6)

Screenshot of the main TI-Boy CE settings page at daf0ec6ce49ead5057ad895b016eef46527f7e43 built with `build "-DVERSION=\"cool version\""` or `./build.sh '-DVERSION="cool version"'`:

![image](https://github.com/user-attachments/assets/29b16b3e-2645-4beb-ba40-77f78513dee8)